### PR TITLE
Fix overlay text contrast

### DIFF
--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -81,7 +81,7 @@ export default function Navigation() {
             whileTap={{ scale: 0.95 }}
           >
             <span className="mr-2">J</span>
-            <span className={`${isScrolled ? 'text-white' : 'text-violet-900'}`}>ames</span>
+            <span className={`${isScrolled ? 'text-white' : 'text-graphite'}`}>ames</span>
           </motion.a>
           
           {/* Desktop Navigation */}

--- a/src/components/sections/Craft.tsx
+++ b/src/components/sections/Craft.tsx
@@ -62,7 +62,7 @@ export default function Craft() {
               <motion.div key={skill.name} variants={item}>
                 <div className="flex justify-between mb-2">
                   <span className="font-medium">{skill.name}</span>
-                  <span className="text-neon">{skill.level}%</span>
+                  <span className="text-graphite dark:text-neon">{skill.level}%</span>
                 </div>
                 <div className="h-2 bg-violet/20 rounded-full overflow-hidden">
                   <motion.div 

--- a/src/components/sections/Roots.tsx
+++ b/src/components/sections/Roots.tsx
@@ -72,11 +72,11 @@ export default function Roots() {
                 variants={item}
               >
                 <div className={`w-1/2 px-8 ${index % 2 === 0 ? 'text-right' : 'text-left'}`}>
-                  <span className="inline-block px-3 py-1 mb-2 text-sm font-medium text-neon bg-neon/10 rounded-full">
+                  <span className="inline-block px-3 py-1 mb-2 text-sm font-medium bg-neon/10 text-graphite dark:bg-neon/20">
                     {event.year}
                   </span>
                   <h3 className="text-xl font-bold mb-2">{event.title}</h3>
-                  <p className="text-gray-300">{event.description}</p>
+                  <p className="text-graphite dark:text-gray-300">{event.description}</p>
                 </div>
                 
                 {/* Timeline dot */}

--- a/src/components/sections/filters/ProjectCard.tsx
+++ b/src/components/sections/filters/ProjectCard.tsx
@@ -45,9 +45,9 @@ export default function ProjectCard({ project }: ProjectCardProps) {
         />
         
         <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent z-10" />
-        <div className="absolute bottom-0 left-0 p-6 z-20">
-          <h3 className="text-2xl font-bold mb-2">{project.title}</h3>
-          <div className="flex flex-wrap gap-2">
+        <div className="absolute bottom-0 left-0 p-6 z-20 text-white">
+          <h3 className="text-2xl font-bold mb-2 text-white">{project.title}</h3>
+          <div className="flex flex-wrap gap-2 text-white">
             {project.tags.map(tag => (
               <span key={tag} className="text-xs bg-neon-cyan/20 dark:bg-neon-cyan/10 text-neon-cyan dark:text-neon-cyan px-2 py-1 rounded">
                 {tag}

--- a/src/components/sections/filters/ProjectFilter.tsx
+++ b/src/components/sections/filters/ProjectFilter.tsx
@@ -48,7 +48,7 @@ function FilterButton({ isActive, onClick, label }: FilterButtonProps) {
         onClick={onClick}
         className={`relative z-10 rounded-full px-4 py-2 text-sm font-medium transition-colors duration-200 sm:text-base ${
           isActive
-            ? 'text-white dark:text-white'
+            ? 'text-graphite dark:text-white'
             : 'text-graphite hover:text-neon-cyan dark:text-gray-300 dark:hover:text-neon-cyan'
         }`}
         aria-current={isActive ? 'page' : undefined}

--- a/src/components/ui/InteractiveButton.tsx
+++ b/src/components/ui/InteractiveButton.tsx
@@ -30,7 +30,7 @@ export default function InteractiveButton({
   const baseStyle = 'inline-flex items-center justify-center rounded-md font-medium transition-all focus:outline-none focus:ring-2 focus:ring-neon-cyan focus:ring-offset-2';
   
   const variantStyles = {
-    primary: 'bg-gradient-to-r from-neon-cyan to-inti-gold text-white shadow-md hover:shadow-lg shadow-neon-cyan/20 hover:shadow-neon-cyan/30',
+    primary: 'bg-gradient-to-r from-neon-cyan to-inti-gold text-graphite shadow-md hover:shadow-lg shadow-neon-cyan/20 hover:shadow-neon-cyan/30',
     secondary: 'bg-white dark:bg-card border-2 border-neon-cyan/70 text-violet-900 dark:text-white hover:border-neon-cyan hover:text-violet-950 dark:hover:text-white',
     ghost: 'bg-transparent text-violet-900 dark:text-gray-200 hover:bg-violet-50 dark:hover:bg-muted/50 hover:text-violet-950 dark:hover:text-neon-cyan',
   };


### PR DESCRIPTION
## Summary
- darken Navigation brand before scroll
- use graphite percentage text in Craft section
- adjust Roots timeline badge and description colors
- update ProjectFilter active button text for light mode
- ensure ProjectCard overlay text is white for readability

## Testing
- `pnpm build` *(fails: next not found because dependencies aren't installed)*
- `pnpm exec jest` *(fails: command "jest" not found)*